### PR TITLE
ActiveGS now an "Open In..." target.

### DIFF
--- a/ActiveGS_iOS/activegs.plist
+++ b/ActiveGS_iOS/activegs.plist
@@ -6,6 +6,63 @@
 	<string>English</string>
 	<key>CFBundleDisplayName</key>
 	<string>ActiveGS</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>Apple // 2MG Image</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.disk-image-2mg</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>Apple // DSK Image</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.disk-image-dsk</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>Apple // ZIP Disk Image</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.disk-image-zip</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>Unknown File</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
@@ -50,5 +107,71 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public-data</string>
+				<string>public.disk-image</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Apple // Disk Image - 2MG</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.apple.disk-image-2mg</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>Item 0</key>
+				<string>2MG</string>
+				<key>public.filename-extension</key>
+				<array/>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public-data</string>
+				<string>public.disk-image</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Apple // Disk Image - DSK</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.apple.disk-image-dsk</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>DSK</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.archive</string>
+				<string>public-data</string>
+				<string>public.disk-image</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Apple // Disk Image -ZIP</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.apple.disk-image-zip</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>ZIP</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/ActiveGS_iOS/activegs.plist
+++ b/ActiveGS_iOS/activegs.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleDisplayName</key>

--- a/Common.iphone/activegsList.mm
+++ b/Common.iphone/activegsList.mm
@@ -572,7 +572,27 @@ static NSInteger compareImagesUsingSelector(id p1, id p2, void *context)
 {
     NSLog(@"activeGSList viewWillAppear %@",self);
 
-
+    
+    // Move files from Documents/Inbox to Documents (Items arriving through iOS "Open In"
+    NSLog(@"Moving files from Documents/Inbox to Documents so they're visible");
+    //Turn every file inside the directory into an array
+    // Note to self: remember to actually put files in the Documents folder. Use the code in the apparopriately marked file
+    NSArray *path = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    //strings to actually get the directories
+    NSString *appFolderPath = [path objectAtIndex:0];
+    NSString *inboxAppFolderPath = [appFolderPath stringByAppendingString:@"/Inbox"]; //add ".plist" to the end of the recipe name
+    
+    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    
+    NSArray *inboxContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[NSString stringWithFormat:inboxAppFolderPath, documentsDirectory] error:nil];
+    
+    //move all the files over
+    for (int i = 0; i != [inboxContents count]; i++) {
+        NSString *oldPath = [NSString stringWithFormat:@"%@/%@", inboxAppFolderPath, [inboxContents objectAtIndex:i]];
+        NSString *newPath = [NSString stringWithFormat:@"%@/%@", appFolderPath, [inboxContents objectAtIndex:i]];
+        [[NSFileManager defaultManager] moveItemAtPath:oldPath toPath:newPath error:nil];
+    }
+    
      if (self.sourceName)
      {
 #ifndef   ACTIVEGS_BACKGROUNDIMAGE
@@ -591,6 +611,7 @@ static NSInteger compareImagesUsingSelector(id p1, id p2, void *context)
     
 	[super viewDidLoad];
 	
+    
     
     // IOS8 ISSUE !!!!! DefaultRawHeight = UITableViewAutomaticDimension
     


### PR DESCRIPTION
Change to activegs.plist allows "opening in" disk images from other apps (Files, Safari, etc.) (restoring that functionality since the app can't live on the App Store anyway).  This is super useful now especially now that the repository for the 2GS disk images appears to be offline.

The refresh option from tapping "My 2GS" title now adds any just-added disk images to the Favorites list.  Otherwise they would only show up after a relaunch of the app.